### PR TITLE
BluetoothSSH

### DIFF
--- a/pushback/bluetoothssh.sh
+++ b/pushback/bluetoothssh.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# This script is designed to allow the jetson nano to open an SSH connection over bluetooth
+
+set -euo pipefail
+
+# Function to clean on exit
+cleanup() {
+    echo "Cleaning up my oil spill..."
+    sudo pkill -f "rfcomm listen /dev/rfcomm0" || true
+    sudo pkill -f "socat TCP-LISTEN" || true
+    sudo hciconfig hci0 down || true
+    bluetoothctl <<EOF >/dev/null 2>&1 || true
+discoverable off
+pairable off
+EOF
+}
+trap cleanup EXIT
+
+# Package check
+for pack in bluez openssh-server socat; do
+    if ! dpkg -l | grep -q "^li $pack "; then
+        echo "Installing $pack..."
+        sudo apt-get install -y "$pack"
+    fi
+done
+
+sudo systemctl restart bluetooth
+sleep 2
+sudo systemctl enable --now ssh
+
+# Discoverability logic
+bluetoothctl << EOF
+power on
+agent on
+default-agent
+discoverable on
+pairable on
+EOF
+
+echo "Bluetooth is discoverable and pairable, awaiting SSH connection..."
+
+# Get the bluetooth MAC address
+BT_ADDR=$(bluetoothctl show | grep "Controller" | awk '{print $2}')
+echo "Bluetooth MAC address: $BT_ADDR"
+
+# pick a TCP port if 22 is in use
+if ss -ltn "( sport = :22 )" | grep -q LISTEN; then
+    PORT=2222
+else
+    PORT=22
+fi
+echo "Using TCP port $PORT for SSH"
+
+sudo hciconfig hci0 up
+sudo rfcomm release 0 || true
+
+cat > /tmp/bt_ssh_handler.sh << 'HANDLER_EOF'
+#!/bin/bash
+# This script handles each Bluetooth connection
+exec socat STDIO TCP:localhost:22
+HANDLER_EOF
+chmod +x /tmp/bt_ssh_handler.sh
+
+echo "Starting Bluetooth SSH bridge..."
+sudo rfcomm listen /dev/rfcomm0 1 /tmp/bt_ssh_handler.sh &
+RFCOMM_PID=$!
+
+echo "Bluetooth SSH bridge active (pid $RFCOMM_PID)"
+echo ""
+echo "========================" CONNECTION INSTRUCTIONS ========================"
+"Jetson Nano Bluetooth MAC: $BT_ADDR"
+""
+"FROM CLIENT DEVICE:"
+"1. Pair: bluetoothctl pair $BT_ADDR"
+"2. Trust: bluetoothctl trust $BT_ADDR"
+"3. Connect: sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+"4. SSH: ssh username@localhost -o ProxyCommand='cat /dev/rfcomm0'"
+""
+"SIMPLE TEST:"
+"   sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+"   # You should see SSH banner appear automatically"
+echo "========================================================================="
+
+while true; do
+    if ! kill -0 $RFCOMM_PID 2>/dev/null; then
+        echo "Restarting bridge..."
+        sudo rfcomm listen /dev/rfcomm0 1 /tmp/bt_ssh_handler.sh &
+        RFCOMM_PID=$!
+    fi
+    sleep 0.5
+done


### PR DESCRIPTION
This pull request adds a new script, `pushback/bluetoothssh.sh`, which enables the Jetson Nano to accept SSH connections over Bluetooth. The script automates Bluetooth setup, manages required packages, and provides user instructions for connecting via SSH over a Bluetooth RFCOMM channel.

Bluetooth SSH bridge setup:

* Introduces a script that configures Bluetooth discoverability and pairability, starts the necessary services, and sets up an RFCOMM listener to bridge Bluetooth connections to the SSH service.
* Automatically checks for and installs required packages (`bluez`, `openssh-server`, `socat`) and ensures the SSH and Bluetooth services are running.

Connection instructions and usability:

* Displays the Jetson Nano's Bluetooth MAC address and provides detailed step-by-step instructions for clients to pair, trust, connect, and SSH into the device over Bluetooth.

Robustness and cleanup:

* Implements a cleanup routine to gracefully shut down Bluetooth services and listeners when the script exits, preventing resource leaks.
* Monitors the RFCOMM listener process and automatically restarts it if it stops, ensuring continuous availability.