### PR TITLE
testington

### DIFF
--- a/pushback/bluetoothssh.sh
+++ b/pushback/bluetoothssh.sh
@@ -54,7 +54,7 @@ echo "Using TCP port $PORT for SSH"
 sudo hciconfig hci0 up
 sudo rfcomm release 0 || true
 
-cat > /tmp/bt_ssh_handler.sh << 'HANDLER_EOF'
+cat > /tmp/bt_ssh_handler.sh << HANDLER_EOF
 #!/bin/bash
 # This script handles each Bluetooth connection
 exec socat STDIO TCP:localhost:$PORT


### PR DESCRIPTION
This pull request updates the Bluetooth SSH handler script to improve its flexibility. The most important change is that the script now uses the value of the `$PORT` environment variable for the TCP connection, instead of always connecting to port 22.

Bluetooth SSH handler improvement:

* Modified the handler script in `pushback/bluetoothssh.sh` to use `$PORT` for the TCP connection instead of the hardcoded port 22, allowing dynamic port selection.