### PR TITLE
testington 2

### DIFF
--- a/pushback/bluetoothssh.sh
+++ b/pushback/bluetoothssh.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 
 # Function to clean on exit
 cleanup() {
-    echo "Cleaning up my oil spill..."
+    echo "Cleaning up..."
     sudo pkill -f "rfcomm listen /dev/rfcomm0" || true
-    sudo pkill -f "socat TCP-LISTEN" || true
-    sudo hciconfig hci0 down || true
+    sudo pkill -f "socat" || true
+    sudo sdptool del SP || true
+    sudo rfcomm release 0 || true
     bluetoothctl <<EOF >/dev/null 2>&1 || true
 discoverable off
 pairable off
@@ -18,7 +19,7 @@ trap cleanup EXIT
 
 # Package check
 for pack in bluez openssh-server socat; do
-    if ! dpkg -l | grep -q "^li $pack "; then
+    if ! dpkg -l | grep -q "^ii  $pack "; then
         echo "Installing $pack..."
         sudo apt-get install -y "$pack"
     fi
@@ -28,22 +29,22 @@ sudo systemctl restart bluetooth
 sleep 2
 sudo systemctl enable --now ssh
 
-# Discoverability logic
+# Configure Bluetooth
 bluetoothctl << EOF
 power on
-agent on
+agent NoInputNoOutput
 default-agent
 discoverable on
 pairable on
 EOF
 
-echo "Bluetooth is discoverable and pairable, awaiting SSH connection..."
+echo "Bluetooth is discoverable and pairable"
 
 # Get the bluetooth MAC address
 BT_ADDR=$(bluetoothctl show | grep "Controller" | awk '{print $2}')
 echo "Bluetooth MAC address: $BT_ADDR"
 
-# pick a TCP port if 22 is in use
+# Pick a TCP port
 if ss -ltn "( sport = :22 )" | grep -q LISTEN; then
     PORT=2222
 else
@@ -51,41 +52,33 @@ else
 fi
 echo "Using TCP port $PORT for SSH"
 
-sudo hciconfig hci0 up
-sudo rfcomm release 0 || true
+# Register Serial Port Profile service
+sudo sdptool add --channel=1 SP
 
-cat > /tmp/bt_ssh_handler.sh << HANDLER_EOF
-#!/bin/bash
-# This script handles each Bluetooth connection
-exec socat STDIO TCP:localhost:$PORT
-HANDLER_EOF
-chmod +x /tmp/bt_ssh_handler.sh
-
-echo "Starting Bluetooth SSH bridge..."
-sudo rfcomm listen /dev/rfcomm0 1 /tmp/bt_ssh_handler.sh &
+# Start rfcomm in background
+sudo rfcomm release 0 2>/dev/null || true
+sudo rfcomm watch /dev/rfcomm0 1 sh -c "socat STDIO TCP:localhost:$PORT" &
 RFCOMM_PID=$!
 
 echo "Bluetooth SSH bridge active (pid $RFCOMM_PID)"
 echo ""
-echo "========================" CONNECTION INSTRUCTIONS ========================"
-"Jetson Nano Bluetooth MAC: $BT_ADDR"
-""
-"FROM CLIENT DEVICE:"
-"1. Pair: bluetoothctl pair $BT_ADDR"
-"2. Trust: bluetoothctl trust $BT_ADDR"
-"3. Connect: sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
-"4. SSH: ssh username@localhost -o ProxyCommand='cat /dev/rfcomm0'"
-""
-"SIMPLE TEST:"
-"   sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
-"   # You should see SSH banner appear automatically"
+echo "======================== CONNECTION INSTRUCTIONS ========================"
+echo "Jetson Bluetooth MAC: $BT_ADDR"
+echo ""
+echo "FROM CLIENT DEVICE:"
+echo "1. Pair: bluetoothctl pair $BT_ADDR"
+echo "2. Trust: bluetoothctl trust $BT_ADDR"
+echo "3. Connect: sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+echo "4. SSH: ssh username@localhost -o ProxyCommand='socat - /dev/rfcomm0'"
+echo ""
 echo "========================================================================="
 
+# Monitor the connection
 while true; do
     if ! kill -0 $RFCOMM_PID 2>/dev/null; then
-        echo "Restarting bridge..."
-        sudo rfcomm listen /dev/rfcomm0 1 /tmp/bt_ssh_handler.sh &
+        echo "Bridge died, restarting..."
+        sudo rfcomm watch /dev/rfcomm0 1 sh -c "socat STDIO TCP:localhost:$PORT" &
         RFCOMM_PID=$!
     fi
-    sleep 0.5
+    sleep 2
 done


### PR DESCRIPTION
This pull request refactors and improves the `pushback/bluetoothssh.sh` script for setting up a Bluetooth SSH bridge. The changes focus on reliability, Bluetooth configuration, and simplifying connection instructions. Key updates include improved cleanup logic, more robust Bluetooth service setup, and streamlined client instructions.

**Bluetooth service and connection setup:**

* Replaced manual service script and `rfcomm listen` with `rfcomm watch` and in-line `socat` command, simplifying the bridge startup and restart logic. Serial Port Profile (SP) is now registered using `sdptool add`, and the service is restarted automatically if it dies.
* Updated Bluetooth configuration to use `agent NoInputNoOutput` for easier pairing, and improved discoverability and pairability setup.

**Cleanup and reliability improvements:**

* Enhanced the `cleanup` function to remove SP service, release rfcomm, and ensure all related processes are terminated, making shutdown more reliable.

**Package installation check:**

* Fixed the package check to correctly identify installed packages by matching the proper `dpkg -l` output.

**User instructions and messaging:**

* Simplified and corrected connection instructions, replacing the previous manual steps and clarifying the use of `socat` for SSH ProxyCommand on the client.