### PR TITLE
testington 3, the 3rd awakening (of the jetson nano orin)

### DIFF
--- a/pushback/bluetoothssh.sh
+++ b/pushback/bluetoothssh.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# filepath: /home/s3nt/Downloads/programming/VAIC_25_26/pushback/bluetoothssh.sh
+#!/bin/bash
 # This script is designed to allow the jetson nano to open an SSH connection over bluetooth
 
 set -euo pipefail
@@ -6,7 +8,7 @@ set -euo pipefail
 # Function to clean on exit
 cleanup() {
     echo "Cleaning up..."
-    sudo pkill -f "rfcomm listen /dev/rfcomm0" || true
+    sudo pkill -f "rfcomm" || true
     sudo pkill -f "socat" || true
     sudo sdptool del SP || true
     sudo rfcomm release 0 || true
@@ -29,56 +31,96 @@ sudo systemctl restart bluetooth
 sleep 2
 sudo systemctl enable --now ssh
 
-# Configure Bluetooth
-bluetoothctl << EOF
-power on
-agent NoInputNoOutput
-default-agent
-discoverable on
-pairable on
-EOF
-
-echo "Bluetooth is discoverable and pairable"
-
-# Get the bluetooth MAC address
+# Get the bluetooth MAC address first
 BT_ADDR=$(bluetoothctl show | grep "Controller" | awk '{print $2}')
 echo "Bluetooth MAC address: $BT_ADDR"
 
+# Configure Bluetooth with proper agent
+bluetoothctl << EOF
+power on
+pairable on
+discoverable on
+EOF
+
+# Start bluetooth-agent in background to auto-accept pairing
+echo "Starting Bluetooth agent..."
+sudo bt-agent -c NoInputNoOutput &
+BT_AGENT_PID=$!
+sleep 2
+
+echo "Bluetooth is discoverable and pairable (auto-accept enabled)"
+
 # Pick a TCP port
 if ss -ltn "( sport = :22 )" | grep -q LISTEN; then
-    PORT=2222
+    PORT=22
 else
     PORT=22
 fi
 echo "Using TCP port $PORT for SSH"
 
-# Register Serial Port Profile service
+# Register Serial Port Profile service with better parameters
+sudo sdptool del SP 2>/dev/null || true
 sudo sdptool add --channel=1 SP
 
-# Start rfcomm in background
-sudo rfcomm release 0 2>/dev/null || true
-sudo rfcomm watch /dev/rfcomm0 1 sh -c "socat STDIO TCP:localhost:$PORT" &
+# Verify SPP registration
+echo "Registered services:"
+sudo sdptool browse local
+
+# Release any existing rfcomm bindings
+for i in {0..9}; do
+    sudo rfcomm release $i 2>/dev/null || true
+done
+
+# Start rfcomm listener with explicit logging
+echo "Starting RFCOMM listener on channel 1..."
+sudo rfcomm listen /dev/rfcomm0 1 socat STDIO TCP:localhost:$PORT 2>&1 &
 RFCOMM_PID=$!
+
+# Give it time to start
+sleep 2
+
+# Verify it's running
+if ! kill -0 $RFCOMM_PID 2>/dev/null; then
+    echo "ERROR: RFCOMM failed to start!"
+    exit 1
+fi
 
 echo "Bluetooth SSH bridge active (pid $RFCOMM_PID)"
 echo ""
 echo "======================== CONNECTION INSTRUCTIONS ========================"
 echo "Jetson Bluetooth MAC: $BT_ADDR"
 echo ""
-echo "FROM CLIENT DEVICE:"
-echo "1. Pair: bluetoothctl pair $BT_ADDR"
-echo "2. Trust: bluetoothctl trust $BT_ADDR"
-echo "3. Connect: sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
-echo "4. SSH: ssh username@localhost -o ProxyCommand='socat - /dev/rfcomm0'"
+echo "FROM CLIENT DEVICE (Linux):"
+echo "1. Scan: bluetoothctl scan on (wait to see device)"
+echo "2. Pair: bluetoothctl pair $BT_ADDR"
+echo "3. Trust: bluetoothctl trust $BT_ADDR"
+echo "4. Connect: sudo rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+echo "5. In another terminal: ssh <username>@localhost -p 22 -o ProxyCommand='socat - /dev/rfcomm0'"
+echo ""
+echo "FROM CLIENT DEVICE (Android with Termux):"
+echo "1. Pair device normally through Android Bluetooth settings"
+echo "2. In Termux: pkg install socat openssh"
+echo "3. rfcomm connect /dev/rfcomm0 $BT_ADDR 1"
+echo "4. ssh <username>@localhost -o ProxyCommand='socat - /dev/rfcomm0'"
 echo ""
 echo "========================================================================="
+echo ""
+echo "Monitoring connections... (Ctrl+C to stop)"
 
-# Monitor the connection
+# Monitor the connection with detailed logging
 while true; do
     if ! kill -0 $RFCOMM_PID 2>/dev/null; then
-        echo "Bridge died, restarting..."
-        sudo rfcomm watch /dev/rfcomm0 1 sh -c "socat STDIO TCP:localhost:$PORT" &
+        echo "[$(date)] Bridge died, restarting..."
+        sudo rfcomm release 0 2>/dev/null || true
+        sudo rfcomm listen /dev/rfcomm0 1 socat STDIO TCP:localhost:$PORT 2>&1 &
         RFCOMM_PID=$!
     fi
-    sleep 2
+    
+    # Check for connected devices
+    CONNECTED=$(bluetoothctl info 2>/dev/null | grep "Connected: yes" || true)
+    if [ -n "$CONNECTED" ]; then
+        echo "[$(date)] Device connected!"
+    fi
+    
+    sleep 5
 done


### PR DESCRIPTION
This pull request significantly refactors the `bluetoothssh.sh` script to improve reliability, user guidance, and Bluetooth service management for SSH connections over Bluetooth on Jetson Nano. The changes enhance the setup process, automate pairing acceptance, improve connection monitoring, and provide clearer instructions for both Linux and Android clients.

Bluetooth setup and pairing improvements:
* Automated Bluetooth pairing acceptance is enabled by running `bt-agent` in the background, simplifying the client connection process.
* The script now retrieves and displays the device's Bluetooth MAC address earlier in the process for user reference.

Service registration and RFCOMM management:
* Serial Port Profile (SPP) registration is improved with explicit cleanup and verification, and RFCOMM bindings are robustly released before starting a new listener.
* The RFCOMM listener is started with enhanced logging and error checks to ensure reliable operation.

User instructions and connection monitoring:
* Connection instructions are expanded and clarified for both Linux and Android (Termux) clients, including step-by-step pairing and SSH usage.
* The connection monitoring loop now provides detailed logs, checks for active connections, and automatically restarts the bridge if it dies.

Cleanup and reliability:
* The cleanup function is updated to more reliably terminate background processes and release resources, ensuring proper shutdown.